### PR TITLE
Allow to only generate a MachineConfig file without applying it

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ Commands to create MachineConfig for driver binding
 ```
 ansible-playbook play.yaml -e network_ids="d6441a96-b050-4119-85df-7cbca5d18314,6363fdc6-8754-4075-9040-4a44e481ef18"
 ```
+
+If you just want to generate a MachineConfig YAML file without applying it:
+```
+ansible-playbook play.yaml -e network_ids="d6441a96-b050-4119-85df-7cbca5d18314,6363fdc6-8754-4075-9040-4a44e481ef18" --extra-vars "mc_config_file=/tmp/vhostuser.yaml"
+```

--- a/roles/sos-vhostuser/defaults/main.yml
+++ b/roles/sos-vhostuser/defaults/main.yml
@@ -23,3 +23,5 @@ nwid_conf_file_path: "vhostuser-bind.conf.j2"
 
 contents: []
 systemd: []
+
+# mc_config_file: <mc config file location>

--- a/roles/sos-vhostuser/tasks/main.yml
+++ b/roles/sos-vhostuser/tasks/main.yml
@@ -21,5 +21,14 @@
         source: "{{ lookup('template', nwid_conf_file_path) }}"
 
 - name: create mc config
+  when:
+  - mc_config_file is not defined
   k8s:
     definition: "{{ lookup('template', mc_file_path) }}"
+
+- name: create mc config file
+  when:
+  - mc_config_file is defined
+  copy:
+    dest: "{{ mc_config_file }}"
+    content: "{{ lookup('template', mc_file_path) }}"


### PR DESCRIPTION
This will allow to not apply the config in k8s, only generate a file in
a defined location.
